### PR TITLE
Added feature to generate subtasks using OpenAI API

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, request, redirect, url_for
 from flask_sqlalchemy import SQLAlchemy
+import openai
 
 # Initialize the Flask app
 app = Flask(__name__)
@@ -56,6 +57,27 @@ def complete_task(task_id):
     task = Task.query.get(task_id)
     if task:
         task.completed = not task.completed  # Toggle the completed status
+        db.session.commit()
+    return redirect(url_for('index'))
+
+
+
+
+
+@app.route('/generate_subtasks/<int:task_id>', methods=['POST'])
+def generate_subtasks(task_id):
+    task = Task.query.get(task_id)
+    if task:
+        prompt = f"Generate subtasks for the following task: {task.title}
+
+Only return the subtasks and nothing else."
+        response = openai.Completion.create(
+            engine="text-davinci-003",
+            prompt=prompt,
+            max_tokens=150
+        )
+        subtasks = response.choices[0].text.strip()
+        task.description += f"\n\nSubtasks:\n{subtasks}"
         db.session.commit()
     return redirect(url_for('index'))
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -63,7 +63,7 @@
                             <div class="textarea-wrapper">
                                 <textarea name="description" class="description-textarea" id="textarea-{{ task.id }}"
                                     oninput="autoResize(this);">{{ task.description }}</textarea>
-                                <button type="button" class="ai-button">
+                                <button type="button" class="ai-button" onclick="generateSubtasks({{ task.id }});">
                                     ✨
                                 </button>
                             </div>
@@ -103,6 +103,18 @@
                 autoResize(textarea);
             });
         });
+
+        function generateSubtasks(taskId) {
+            fetch(`/generate_subtasks/${taskId}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            }).then(response => response.json())
+              .then(data => {
+                  // Handle the response if needed
+              });
+        }
     </script>
 </body>
 


### PR DESCRIPTION
Added a new route `/generate_subtasks/<int:task_id>` in `app.py` to call the OpenAI API and generate subtasks for a given task. Updated the `index.html` to include a new button with class `ai-button` that triggers the `generateSubtasks` function when clicked, which sends a POST request to the new route. This feature will allow users to easily generate subtasks for their tasks by clicking a button, and the OpenAI API will only return the subtasks and nothing else.

This PR fixes #8