### PR TITLE
Fix prompt string syntax error and update openAI version

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,9 +68,7 @@ def complete_task(task_id):
 def generate_subtasks(task_id):
     task = Task.query.get(task_id)
     if task:
-        prompt = f"Generate subtasks for the following task: {task.title}
-
-Only return the subtasks and nothing else."
+        prompt = f"Generate subtasks for the following task: {task.title}. Only return the subtasks and nothing else."
         response = openai.Completion.create(
             engine="text-davinci-003",
             prompt=prompt,


### PR DESCRIPTION
Fixed prompt string syntax error and updated openAI version

Explanation: The prompt string was updated to include a period at the end and the old version of openAI was replaced with the new version.

This PR fixes #10